### PR TITLE
Add Ipv6 test to STF sites

### DIFF
--- a/src/Function/STFRequest.cs
+++ b/src/Function/STFRequest.cs
@@ -101,6 +101,10 @@ namespace Function
             testSuiteResponse.Endpoints.Add("FileShare", response.StatusCode);
             log.LogInformation("FileShare: " + response.StatusCode.ToString());
 
+            response = Helper.SendRequest(client, windowsAppUrl + "/Ipv6", HttpMethod.Post);
+            testSuiteResponse.Endpoints.Add("Ipv6", response.StatusCode);
+            log.LogInformation("Ipv6: " + response.StatusCode.ToString());
+
             string jsonString = JsonConvert.SerializeObject(testSuiteResponse, Formatting.Indented);
             log.LogInformation(jsonString);
 
@@ -194,6 +198,10 @@ namespace Function
             response = Helper.SendRequest(client, linuxAppUrl + "/FileShare", HttpMethod.Post);
             testSuiteResponse.Endpoints.Add("FileShare", response.StatusCode);
             log.LogInformation("FileShare: " + response.StatusCode.ToString());
+
+            response = Helper.SendRequest(client, linuxAppUrl + "/Ipv6", HttpMethod.Post);
+            testSuiteResponse.Endpoints.Add("Ipv6", response.StatusCode);
+            log.LogInformation("Ipv6: " + response.StatusCode.ToString());
 
             string jsonString = JsonConvert.SerializeObject(testSuiteResponse, Formatting.Indented);
             log.LogInformation(jsonString);

--- a/src/SwiftTestingFrameworkAPI/Controllers/Ipv6Controller.cs
+++ b/src/SwiftTestingFrameworkAPI/Controllers/Ipv6Controller.cs
@@ -21,7 +21,7 @@ namespace SwiftTestingFrameworkAPI.Controllers
         [HttpGet]
         public TestResponse GetInfo()
         {
-            string testDetails = "Establishes a TCP connection with a public IPv6 address. (ipv6.google.com)";
+            string testDetails = "Sends a http request to a public IPv6 address. (https://ipv6.google.com)";
             return new TestResponse(Constants.ApiVersion, TestName, string.Empty, testDetails, string.Empty);
         }
 
@@ -33,14 +33,7 @@ namespace SwiftTestingFrameworkAPI.Controllers
             try
             {
  
-                if (OperatingSystem.IsWindows())
-                {
-                    p = Helper.StartProcess("tcpping.exe", Constants.PublicIpv6Endpoint);
-                }
-                else
-                {
-                    p = Helper.StartProcess("curl", $"--connect-timeout 5 {Constants.PublicIpv6Endpoint}");
-                }
+                p = Helper.StartProcess("curl", $"--connect-timeout 5 {Constants.PublicIpv6Endpoint}");
 
                 if (p.ExitCode == 0)
                 {

--- a/src/SwiftTestingFrameworkAPI/Controllers/Ipv6Controller.cs
+++ b/src/SwiftTestingFrameworkAPI/Controllers/Ipv6Controller.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using SwiftTestingFrameworkAPI.Utils;
+
+namespace SwiftTestingFrameworkAPI.Controllers
+{
+    [ApiController]
+    [Route("Ipv6")]
+    public class Ipv6Controller : ControllerBase
+    {
+
+        private readonly ILogger<Ipv6Controller> _logger;
+
+        private const string TestName = "Ipv6";
+
+        public Ipv6Controller(ILogger<Ipv6Controller> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public TestResponse GetInfo()
+        {
+            string testDetails = "Establishes a TCP connection with a public IPv6 address. (ipv6.google.com)";
+            return new TestResponse(Constants.ApiVersion, TestName, string.Empty, testDetails, string.Empty);
+        }
+
+        [HttpPost]
+        public ObjectResult SendIpv6Request()
+        {
+            Helper.ProcessOutput p;
+            TestResponse testResponse;
+            try
+            {
+ 
+                if (OperatingSystem.IsWindows())
+                {
+                    p = Helper.StartProcess("tcpping.exe", Constants.PublicIpv6Endpoint);
+                }
+                else
+                {
+                    p = Helper.StartProcess("curl", $"--connect-timeout 5 {Constants.PublicIpv6Endpoint}");
+                }
+
+                if (p.ExitCode == 0)
+                {
+                    testResponse = new TestResponse(Constants.ApiVersion, TestName, "Success", p.StdOutput, string.Empty);
+                    return StatusCode(200, testResponse);
+                }
+                else
+                {
+                    testResponse = new TestResponse(Constants.ApiVersion, TestName, "Failure", string.Empty, p.StdError);
+                    return StatusCode(555, testResponse);
+                }
+            }
+            catch (Exception ex)
+            {
+                testResponse = new TestResponse(Constants.ApiVersion, TestName, "Failure", string.Empty, ex.Message + ex.StackTrace);
+                return StatusCode(555, testResponse);
+            }
+        }
+    }
+}

--- a/src/SwiftTestingFrameworkAPI/Utils/Constants.cs
+++ b/src/SwiftTestingFrameworkAPI/Utils/Constants.cs
@@ -14,6 +14,6 @@
         public const string PrivateSiteScmHostname = "{0}-privateapp.scm.azurewebsites.net";
         public const string MountFilePath = "/mounts/remote/testfile.txt";
 
-        public const string PublicIpv6Endpoint = "ipv6.google.com";
+        public const string PublicIpv6Endpoint = "https://ipv6.google.com";
     }
 }

--- a/src/SwiftTestingFrameworkAPI/Utils/Constants.cs
+++ b/src/SwiftTestingFrameworkAPI/Utils/Constants.cs
@@ -13,5 +13,7 @@
         public const string PrivateSiteHostname = "{0}-privateapp.azurewebsites.net";
         public const string PrivateSiteScmHostname = "{0}-privateapp.scm.azurewebsites.net";
         public const string MountFilePath = "/mounts/remote/testfile.txt";
+
+        public const string PublicIpv6Endpoint = "ipv6.google.com";
     }
 }

--- a/templates/stf-test.json
+++ b/templates/stf-test.json
@@ -895,6 +895,10 @@
       },
       "location": "[parameters('location')]",
       "kind": "Storage",
+      "properties": {
+        "publicNetworkAccess": "Disabled",
+        "allowBlobPublicAccess": false
+      },
       "sku": {
         "name": "Standard_LRS"
       }


### PR DESCRIPTION
## Description
/ipv6 will now try to curl ipv6.google.com (for linux) or tcpping.exe ipv6.google.com (for windows) to test ipv6 connectivity.

## Testing
- Linux:
![image](https://github.com/user-attachments/assets/0db2e47e-5430-4888-93d0-436c6ca4093b)

East US 2 EUAP has ipv6 hosting config turned on. The linux site will have ipv6 turned on when is not joined to VNET, or joined to VNET without VnetRouteAll enabled. 

So I tested with VNET with VnetRouteAll enabled, and got 555 above. 
Turned off VnetRouteAll and we get 200.

- Windows:
No-VNET
![image](https://github.com/user-attachments/assets/814df8e4-7efd-4748-a95e-605468f673dd)

VNET integrated:
![image](https://github.com/user-attachments/assets/82a29100-602d-47af-93f1-c4dcbecdc41e)



